### PR TITLE
Add support for Bluesky intents

### DIFF
--- a/layouts/partials/hb/modules/social-share-buttons/functions/media.html
+++ b/layouts/partials/hb/modules/social-share-buttons/functions/media.html
@@ -1,4 +1,8 @@
 {{- $media := dict
+  "bluesky" (dict
+    "url" "https://bsky.app/intent/compose?text={text} {url}"
+    "iconColor" "#0285FF"
+  )
   "email" (dict
     "url" "mailto:?subject={subject}&body={text} {url}"
     "icon" "envelope"


### PR DESCRIPTION
A simple addition for Bluesky intents along with other social media share links.